### PR TITLE
fix: added timeouts to avoid memory leaking

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -71,7 +71,15 @@ to quickly create a Cobra application.`,
 			IdleTimeout:  time.Second * 60,
 		}
 
-		http.Handle(metricsEndpoint, promhttp.Handler())
+		opts := promhttp.HandlerOpts{
+			Timeout:             5 * time.Second,
+			MaxRequestsInFlight: 2,
+		}
+		handler := promhttp.InstrumentMetricHandler(
+			prometheus.DefaultRegisterer,
+			promhttp.HandlerFor(prometheus.DefaultGatherer, opts),
+		)
+		http.Handle(metricsEndpoint, handler)
 		http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 			_, err := w.Write([]byte(`<html>
 			 <head><title>php-fpm_exporter</title></head>

--- a/go.mod
+++ b/go.mod
@@ -49,3 +49,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/tomasen/fcgi_client => github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7 h1:W0fAsQ7bC1db4k9O2X6yZvatz/0c/ISyxhmNnc6arZA=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7/go.mod h1:dHpIS7C6YjFguh5vo9QBVEojDoL3vh3v6oEho2HtNyA=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -92,8 +94,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19 h1:ZCmSnT6CLGhfoQ2lPEhL4nsJstKDCw1F1RfN8/smTCU=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19/go.mod h1:SXTY+QvI+KTTKXQdg0zZ7nx0u94QWh8ZAwBQYsW9cqk=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/phpfpm/phpfpm.go
+++ b/phpfpm/phpfpm.go
@@ -163,6 +163,8 @@ func (p *Pool) Update() (err error) {
 
 	defer fcgi.Close()
 
+	fcgi.SetTimeout(time.Duration(3) * time.Second)
+
 	env := map[string]string{
 		"SCRIPT_FILENAME": path,
 		"SCRIPT_NAME":     path,

--- a/phpfpm/phpfpm.go
+++ b/phpfpm/phpfpm.go
@@ -163,7 +163,10 @@ func (p *Pool) Update() (err error) {
 
 	defer fcgi.Close()
 
-	fcgi.SetTimeout(time.Duration(3) * time.Second)
+	err = fcgi.SetTimeout(time.Duration(3) * time.Second)
+	if err != nil {
+		return p.error(err)
+	}
 
 	env := map[string]string{
 		"SCRIPT_FILENAME": path,


### PR DESCRIPTION
This PR adds timeouts to the FCGI-Client and Prometheus HTTP handler.

Originally created and proposed in https://github.com/hipages/php-fpm_exporter/pull/328.