### PR TITLE
fix(ci): Checkout code before running setup-go action

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -31,16 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: "refs/pull/${{ github.event.number }}/merge"
+
     - name: Setup Go
       uses: actions/setup-go@v5.3.0
       with:
         go-version-file: './go.mod'
       id: go
-
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: "refs/pull/${{ github.event.number }}/merge"
 
     - name: Test
       run: go test -coverprofile cover.out ./...

--- a/.github/workflows/test_push.yml
+++ b/.github/workflows/test_push.yml
@@ -34,14 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Setup Go
       uses: actions/setup-go@v5.3.0
       with:
         go-version-file: './go.mod'
       id: go
-
-    - name: Checkout
-      uses: actions/checkout@v4
 
     - name: Test
       run: go test -coverprofile cover.out ./...


### PR DESCRIPTION
In #30 the setup-go action was changed to use the go version from go.mod. This can only be done if the repo has been checked out previously.