### PR TITLE
fix(ci): Replace deprecated SonarQube Scan Action

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -46,7 +46,7 @@ jobs:
       run: go test -coverprofile cover.out ./...
 
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@v4.0.0
+      uses: SonarSource/sonarqube-scan-action@v5.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The old action also referenced a deprecated version of actions/cache which will cause the Test PR workflow to fail starting at March 1st 2025.