### PR TITLE
feat: use distroless/static as base for docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM alpine:3.22.1
+FROM gcr.io/distroless/static-debian12
 
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 
-COPY php-fpm_exporter /
+COPY --chown=nonroot:nonroot php-fpm_exporter /
 
-EXPOSE     9253
+EXPOSE 9253
+USER nonroot:nonroot
+
 ENTRYPOINT [ "/php-fpm_exporter", "server" ]
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
@@ -18,4 +20,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vendor="tonmnn" \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0" \
-      org.label-schema.docker.cmd="docker run -it --rm -e PHP_FPM_SCRAPE_URI=\"tcp://127.0.0.1:9000/status\" hipages/php-fpm_exporter"
+      org.label-schema.docker.cmd="docker run -it --rm -e PHP_FPM_SCRAPE_URI=\"tcp://127.0.0.1:9000/status\" ghcr.io/tonmnn/php-fpm_exporter"


### PR DESCRIPTION
BREAKING CHANGE: Instead of alpine the docker images are now based on distroless-static. This should minimize attack surface of the exporter container, but comes at the cost of not having a shell in the container. The exporter process now also runs as a non-root user to further minimize attack surface.