### PR TITLE
chore(ci): update golangci-lint version to v2.11

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -24,7 +24,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9.2.0
       with:
-        version: v2.5
+        version: v2.11
 
   test:
     name: Test


### PR DESCRIPTION
Missed the test_pr workflow.