### PR TITLE
feat: Pin golang to minor and patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hipages/php-fpm_exporter
 
-go 1.26
+go 1.26.3
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
This will allow to easily trigger image rebuilds when a new golang version is released. Updates of this value should be handled by Renovate.